### PR TITLE
chore(renovate): try larger global concurrent limit

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,8 +10,13 @@
   "minimumReleaseAge": "7 days",
   "patch": { "enabled": false },
   "postUpdateOptions": ["pnpmDedupe"],
-  "prConcurrentLimit": 3,
+  "prConcurrentLimit": 10,
   "packageRules": [
+    {
+      "description": "Non-security updates",
+      "matchCategories": ["!security"],
+      "prConcurrentLimit": 3
+    },
     {
       "description": "Security vulnerability updates",
       "matchCategories": ["security"],


### PR DESCRIPTION
<!--- In the Title above, include the type of change,(feat:, fix:,chore:, etc.]) then provide a general summary of your changes. -->

## ✳️ Description

<!--- Describe your changes in detail -->
Try setting a higher global concurrent limit and smaller limit for non security updates.

## 🔗 Related Issue

<!--- This project only accepts outside pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## 💪 Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Renovate is still not opening vulnerability fix updates.

## ⚗️ How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Needs to merge and run

## 📸 Screenshots (if appropriate):
