### PR TITLE
ci: Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -5,6 +5,9 @@ on:
 jobs:
   renovate:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: 🪙 Get token
         id: get_token


### PR DESCRIPTION
Potential fix for [https://github.com/nx-community/nx-community/security/code-scanning/5](https://github.com/nx-community/nx-community/security/code-scanning/5)

To fix the problem, you must explicitly set the `permissions` key for the workflow or the specific job. Since the job likely needs to read repository contents and possibly open or update pull requests (as Renovate does), the minimum permissions that should be set are `contents: read` and, if pull request writing/updating is needed, `pull-requests: write`. You should add a `permissions:` block under either the root of the workflow or under the `renovate` job. The best practice is to restrict permissions at the job level if only one job needs them, otherwise at the root. In `.github/workflows/renovate.yml`, you should add the permissions block directly under the `renovate:` job definition (line 7), specifying `contents: read` and `pull-requests: write`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
