### PR TITLE
chore(typecheck): use nx inferred typecheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,4 +40,4 @@ jobs:
         run: pnpm exec nx format:check
 
       - name: 📝 Code Quality
-        run: pnpm exec nx affected -t lint spellcheck typescript-check test build e2e-ci
+        run: pnpm exec nx affected -t lint spellcheck typecheck test build e2e-ci

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,8 +1,3 @@
 {
-  "servers": {
-    "nx-mcp": {
-      "type": "sse",
-      "url": "http://localhost:9672/sse"
-    }
-  }
+  "servers": {}
 }

--- a/apps/docs/project.json
+++ b/apps/docs/project.json
@@ -54,13 +54,7 @@
         "jestConfig": "apps/docs/jest.config.ts"
       }
     },
-    "typescript-check": {
-      "executor": "nx:run-commands",
-      "options": {
-        "cwd": "apps/docs",
-        "command": "tsc -p tsconfig.json"
-      }
-    },
+
     "e2e": {
       "executor": "@nx/playwright:playwright",
       "outputs": ["{workspaceRoot}/dist/.playwright/apps/docs"],

--- a/apps/docs/tsconfig.app.json
+++ b/apps/docs/tsconfig.app.json
@@ -2,7 +2,9 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
-    "types": ["node"]
+    "types": ["node"],
+    "composite": true,
+    "declaration": true
   },
   "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
   "include": ["src/**/*.ts"]

--- a/apps/docs/tsconfig.spec.json
+++ b/apps/docs/tsconfig.spec.json
@@ -3,7 +3,9 @@
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
     "module": "commonjs",
-    "types": ["jest", "node"]
+    "types": ["jest", "node"],
+    "composite": true,
+    "declaration": true
   },
   "files": ["src/test-setup.ts"],
   "include": [

--- a/apps/plugins/spellcheck-e2e/tsconfig.spec.json
+++ b/apps/plugins/spellcheck-e2e/tsconfig.spec.json
@@ -3,7 +3,9 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
     "module": "commonjs",
-    "types": ["jest", "node"]
+    "types": ["jest", "node"],
+    "composite": true,
+    "declaration": true
   },
   "include": [
     "jest.config.ts",

--- a/nx.json
+++ b/nx.json
@@ -13,7 +13,7 @@
     "spellcheck": {
       "cache": true
     },
-    "typescript-check": {
+    "typecheck": {
       "cache": true
     },
     "@nx/eslint:lint": {
@@ -48,6 +48,16 @@
       "{workspaceRoot}/.github/workflows/ci.yml"
     ]
   },
+  "plugins": [
+    {
+      "plugin": "@nx/js/typescript",
+      "options": {
+        "typecheck": {
+          "targetName": "typecheck"
+        }
+      }
+    }
+  ],
   "generators": {
     "@nx/web:application": {
       "style": "css",

--- a/packages/plugins/spellcheck/tsconfig.lib.json
+++ b/packages/plugins/spellcheck/tsconfig.lib.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
     "declaration": true,
-    "types": ["node"]
+    "types": ["node"],
+    "composite": true
   },
   "include": ["src/**/*.ts"],
   "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]

--- a/packages/plugins/spellcheck/tsconfig.spec.json
+++ b/packages/plugins/spellcheck/tsconfig.spec.json
@@ -3,12 +3,15 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
     "module": "commonjs",
-    "types": ["jest", "node"]
+    "types": ["jest", "node"],
+    "composite": true,
+    "declaration": true
   },
   "include": [
     "jest.config.ts",
     "src/**/*.test.ts",
     "src/**/*.spec.ts",
-    "src/**/*.d.ts"
+    "src/**/*.d.ts",
+    "src/**/*.ts"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": []
+}


### PR DESCRIPTION
<!--- In the Title above, include the type of change,(feat:, fix:,chore:, etc.]) then provide a general summary of your changes. -->

## ✳️ Description

<!--- Describe your changes in detail -->
Switches repo to use nx inferred typecheck target.

## 🔗 Related Issue

<!--- This project only accepts outside pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## 💪 Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Reduce needs to add manual typecheck targets.

## ⚗️ How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📸 Screenshots (if appropriate):
